### PR TITLE
fix: #56 #57 issue 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Surfy는 사용자의 Chrome에 CDP(Chrome DevTools Protocol)로 연결하여 �
 
 # Linux
 google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-cdp-profile
+
+# Windows
+"C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="C:\chrome-cdp-profile"
 ```
 
 > ⚠️ `--user-data-dir`을 지정하면 깨끗한 프로필로 시작됩니다 (로그인 세션 없음).

--- a/surfy/adapters/llm/langchain_adapter.py
+++ b/surfy/adapters/llm/langchain_adapter.py
@@ -32,7 +32,7 @@ def _load_prompty(name: str) -> str:
     if not prompty_path.exists():
         raise FileNotFoundError(f"Prompt file not found: {prompty_path}")
 
-    content = prompty_path.read_text()
+    content = prompty_path.read_text(encoding="utf-8")
 
     # Split by '---' and take the part after the second '---'
     parts = content.split("---")


### PR DESCRIPTION
## 변경 사항

- Windows 환경에서 prompt 파일 로딩 시 UTF-8 인코딩 명시 (#56)
- Windows Chrome remote debugging 실행 명령어 문서 추가 (#57)

## 상세 내용

### #56 
Windows 환경에서 사용할 수 있는 Chrome 실행 명령어를 문서에 추가함.
"C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="C:\chrome-cdp-profile"

### #57 
Path.read_text()가 Windows 기본 인코딩(cp949)으로 파일을 읽으면서
UTF-8 파일에서 UnicodeDecodeError가 발생하던 문제를 수정함.
encoding="utf-8"을 명시하도록 변경.

## 관련 이슈

Closes #56
Closes #57