### PR TITLE
chore: Gemini 모델명 업데이트 및 Langfuse 설정 가이드 보완(#58 #69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ GOOGLE_API_KEY=AIza...
 
 # LLM Settings
 LLM_PROVIDER=gemini
-LLM_MODEL_NAME=gemini-2.0-flash
+LLM_MODEL_NAME="gemini-3.1-flash-lite-preview"
 LLM_USE_VISION=false
 
 # Browser Settings

--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ docker compose -f docker-compose.langfuse.yml up -d
 1. http://localhost:3000 접속
 2. **Sign Up**을 클릭하여 계정 생성 (이메일, 비밀번호 자유롭게 설정)
 3. Organization 이름 입력 (예: `surfy`)
-4. 로그인 후 좌측 하단 **Settings** -> **API Keys** -> **Create New API Key**
-5. 생성된 **Public Key**와 **Secret Key**를 복사 (Secret Key는 이 시점에만 표시됨)
+4. Project 생성 (처음 사용하는 경우 Project가 없으면 새로운 Project를 먼저 생성해야 합니다.)
+5. 로그인 후 좌측 하단 **Settings** -> **API Keys** -> **Create New API Key**
+6. 생성된 **Public Key**와 **Secret Key**를 복사 (Secret Key는 이 시점에만 표시됨)
 
 **3단계: .env에 키 등록**
 


### PR DESCRIPTION

## 개요
Gemini 모델 서비스 중단에 따른 모델명 업데이트 및 Langfuse 초기 설정 가이드 보완을 제안합니다.

## 변경 사항

### 1. Gemini 모델 업데이트
`gemini-2.0-flash` 모델의 서비스 중단으로 인해 최신 버전으로 업데이트가 필요합니다.
- **AS-IS:** `gemini-2.0-flash`
- **TO-BE:** `gemini-3.1-flash-lite-preview`
- **대상 파일:** `.env.example` 및 관련 설정 파일

### 2. Langfuse 설정 가이드 보완 (README.md)
신규 사용자가 Langfuse 설정 시 프로젝트 생성 단계에서 겪는 혼란을 방지하기 위해 가이드를 수정합니다.
- **추가 내용:** 계정 생성 후 API Key 발급 전 'Project 생성 및 선택' 과정 명시

## 수정 제안 (README.md 예시)
```markdown
**2단계: 계정 생성 및 API 키 발급**

1. http://localhost:3000 접속
2. **Sign Up**을 클릭하여 계정 생성
3. Organization 이름 입력 (예: `surfy`)
4. **Project 생성** (처음 사용하는 경우 새로운 Project를 먼저 생성해야 합니다.)
5. 생성된 Project 선택 후 좌측 하단 **Settings** -> **API Keys** -> **Create New API Key**
6. 생성된 **Public Key**와 **Secret Key** 복사 (Secret Key는 이 시점에만 표시됨)
```

## 기대 효과
- 모델 만료로 인한 API 호출 오류 방지
- 신규 사용자의 온보딩 경험 및 초기 설정 편의성 개선

## 체크리스트
- [ ] `.env.example` 내 모델명 수정 완료
- [ ] README.md 내 Langfuse 가이드 문구 수정 완료