### PR TITLE
feat: Scout 데이터 추출 완료 시 Planner/Actor 건너뛰기

### DIFF
--- a/surfy/adapters/browser/agent_adapter.py
+++ b/surfy/adapters/browser/agent_adapter.py
@@ -104,7 +104,7 @@ def _history_to_route_map(history: AgentHistoryList) -> RouteMap:
     urls = history.urls()
     actions = history.action_names()
     login_wall = _is_login_wall(urls)
-    scout_completed = False
+    scout_completed = bool(history.final_result()) and not login_wall
 
     steps: list[RouteStep] = []
     for i, url in enumerate(urls):

--- a/surfy/graph.py
+++ b/surfy/graph.py
@@ -134,6 +134,9 @@ def compile_graph(
             route_map: RouteMap = await scout.scout(
                 state["command"], max_steps=scout_max_steps, research_result=state.get("research_result")
             )
+            if route_map and route_map.scout_completed:
+                logger.info("Scout already extracted data. Skipping planner.")
+                return {"route_map": route_map, "done": True}
             return {"route_map": route_map}
         except Exception as e:
             logger.warning("Scout failed: %s. Falling back to blind planning.", e)

--- a/tests/test_graph_research.py
+++ b/tests/test_graph_research.py
@@ -98,8 +98,8 @@ async def test_research_node_handles_researcher_failure():
 
 
 @pytest.mark.asyncio
-async def test_scout_completed_routes_to_planner():
-    """scout_completed=True여도 항상 planner로 라우팅된다."""
+async def test_scout_completed_skips_planner():
+    """scout_completed=True이면 planner를 건너뛰고 report로 간다."""
     researcher = MagicMock()
     researcher.research = AsyncMock(return_value=None)
 
@@ -122,7 +122,62 @@ async def test_scout_completed_routes_to_planner():
     result = await graph.ainvoke(_initial_state("네이버 열어"))
 
     assert result["route_map"].scout_completed is True
-    planner.create_plan.assert_awaited_once()
+    assert result["done"] is True
+    planner.create_plan.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scout_completed_skips_planner_and_goes_to_report():
+    researcher = MagicMock()
+    researcher.research = AsyncMock(return_value=ResearchResult(summary="요약", sources=[], raw_results=[]))
+
+    scout = MagicMock()
+    route_map = RouteMap(
+        steps=[
+            RouteStep(
+                url="https://example.com",
+                title="제목",
+                action_taken="관찰",
+                observed_elements=[],
+                notes="데이터 발견",
+            )
+        ],
+        final_url="https://example.com",
+        scout_summary="데이터",
+        scout_completed=True,
+    )
+    scout.scout = AsyncMock(return_value=route_map)
+
+    planner = MagicMock()
+    planner.create_plan = AsyncMock()
+
+    actor = MagicMock()
+    evaluator = MagicMock()
+
+    reporter = MagicMock()
+    reporter.report = AsyncMock(return_value="최종 리포트")
+
+    graph = compile_graph(
+        scout=scout,
+        planner=planner,
+        actor=actor,
+        evaluator=evaluator,
+        researcher=researcher,
+        reporter=reporter,
+        checkpointer=MemorySaver(),
+        handoff_on_auth=False,
+    )
+
+    config = cast(RunnableConfig, {"configurable": {"thread_id": "scout_fast_path"}})
+    result = await graph.ainvoke(_initial_state("데이터 찾아줘"), config)
+
+    state = await graph.aget_state(config)
+    assert state.next == ()
+    assert result["done"] is True
+    assert result["report_result"] == "최종 리포트"
+
+    planner.create_plan.assert_not_awaited()
+    reporter.report.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_scout_adapter.py
+++ b/tests/test_scout_adapter.py
@@ -32,7 +32,7 @@ class MockAgentHistoryList:
         return self._is_successful
 
 
-def test_history_to_route_map_scout_completed_always_false() -> None:
+def test_history_to_route_map_sets_scout_completed_true_on_success() -> None:
     history = MockAgentHistoryList(
         urls=["https://example.com", "https://example.com/done"],
         action_names=["go_to_url", "click_element"],
@@ -42,7 +42,7 @@ def test_history_to_route_map_scout_completed_always_false() -> None:
 
     route_map = _history_to_route_map(history)  # type: ignore[arg-type]
 
-    assert route_map.scout_completed is False
+    assert route_map.scout_completed is True
 
 
 def test_history_to_route_map_sets_scout_completed_false_when_not_done() -> None:
@@ -58,7 +58,7 @@ def test_history_to_route_map_sets_scout_completed_false_when_not_done() -> None
     assert route_map.scout_completed is False
 
 
-def test_history_to_route_map_sets_scout_completed_false_when_failed() -> None:
+def test_history_to_route_map_sets_scout_completed_true_when_final_result_exists() -> None:
     history = MockAgentHistoryList(
         urls=["https://example.com", "https://example.com/fail"],
         action_names=["go_to_url", "click_element"],
@@ -68,7 +68,7 @@ def test_history_to_route_map_sets_scout_completed_false_when_failed() -> None:
 
     route_map = _history_to_route_map(history)  # type: ignore[arg-type]
 
-    assert route_map.scout_completed is False
+    assert route_map.scout_completed is True
 
 
 def test_login_wall_detected_on_login_url() -> None:
@@ -100,7 +100,7 @@ def test_history_to_route_map_overrides_scout_completed_on_login_wall() -> None:
     assert "로그인 필요" in route_map.scout_summary
 
 
-def test_history_to_route_map_non_login_success_still_false() -> None:
+def test_history_to_route_map_non_login_success_is_true() -> None:
     history = MockAgentHistoryList(
         urls=["https://example.com", "https://example.com/dashboard"],
         action_names=["go_to_url", "click_element"],
@@ -110,7 +110,7 @@ def test_history_to_route_map_non_login_success_still_false() -> None:
 
     route_map = _history_to_route_map(history)  # type: ignore[arg-type]
 
-    assert route_map.scout_completed is False
+    assert route_map.scout_completed is True
 
 
 @pytest.mark.asyncio
@@ -142,4 +142,4 @@ async def test_explore_passes_scout_prompt_via_extend_system_message(monkeypatch
     assert captured["extend_system_message"] == adapter._scout_prompt
     assert "정찰은 경로 수집이다" in str(captured["extend_system_message"])
     assert captured["max_steps"] == 3
-    assert route_map.scout_completed is False
+    assert route_map.scout_completed is True


### PR DESCRIPTION
Closes #83

## Summary
- Scout이 이미 데이터를 추출 완료했을 때 Planner/Actor를 건너뛰고 바로 report로 가는 fast-path 추가
- 불필요한 같은 URL 재방문, 중복 스크롤/추출 제거

## Changes
- `surfy/adapters/browser/agent_adapter.py`: `scout_completed = bool(final_result) and not login_wall`
- `surfy/graph.py`: scout_node에서 `scout_completed=True`이면 `done=True` 반환 → report 직행
- `tests/test_graph_research.py`: fast-path 테스트 추가
- `tests/test_scout_adapter.py`: scout_completed 플래그 반영

## Verification
- `make check`: 153 passed, 0 failed