### PR TITLE
feat(landing): add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -1,0 +1,61 @@
+name: Deploy Landing Page to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "landing-page/**"
+      - ".github/workflows/deploy-landing-page.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: landing-page/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: landing-page
+
+      - name: Build landing page
+        run: npm run build
+        working-directory: landing-page
+        env:
+          VITE_BASE_PATH: /surfy/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: landing-page/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/landing-page/vite.config.js
+++ b/landing-page/vite.config.js
@@ -1,8 +1,13 @@
 import { resolve } from 'path';
 import handlebars from 'vite-plugin-handlebars';
 
+const repositoryName = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? '';
+const defaultBase = repositoryName ? `/${repositoryName}/` : '/';
+const base = process.env.VITE_BASE_PATH ?? defaultBase;
+
 export default {
   root: '.',
+  base,
   plugins: [
     handlebars({
       partialDirectory: resolve(__dirname, 'src/partials'),


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Pages workflow that builds `landing-page/` and deploys `landing-page/dist` on pushes to `main`
- set `VITE_BASE_PATH=/surfy/` during CI build so asset URLs resolve correctly on Pages
- make `landing-page/vite.config.js` derive `base` from env/repository context for consistent local + CI behavior